### PR TITLE
adding skip_push option and tags option

### DIFF
--- a/config.py
+++ b/config.py
@@ -34,7 +34,9 @@ class Config:
             'batch_size': int(os.environ.get('TEST_BATCH_SIZE', 400)),
             'test_namespace': os.environ.get("TEST_NAMESPACE"),
             'base_url': '%s://%s' % ("https", os.environ.get("QUAY_HOST")),
-            'test_phases': os.environ.get('TEST_PHASES')
+            'test_phases': os.environ.get('TEST_PHASES'),
+            'tags': os.environ.get('TAGS'),
+            'skip_push': os.environ.get('SKIP_PUSH')
         }
         self.validate_config()
         return self.config

--- a/main.py
+++ b/main.py
@@ -650,20 +650,19 @@ if __name__ == '__main__':
 
     # Calculate all tags to be pushed/pulled
     tags = []
-    for i, repo_size in enumerate(repo_sizes):
-        repo = repos_with_data[i]
-        repo_tags = [
-            '%s/%s/%s:%s' % (env_config["quay_host"], organization, repo, n)
-            for n in range(0, repo_size)
-        ]
-        tags.extend(repo_tags)
-
     explicit_tags = env_config["tags"].split(",")
-    if len(explicit_tags) > 0:
-        tags = []
+    if len(explicit_tags > 0):
         logging.info("explicit tags: %s", explicit_tags)
         for tag in explicit_tags:
             tags.append(tag)
+    else:
+        for i, repo_size in enumerate(repo_sizes):
+            repo = repos_with_data[i]
+            repo_tags = [
+                '%s/%s/%s:%s' % (env_config["quay_host"], organization, repo, n)
+                for n in range(0, repo_size)
+            ]
+            tags.extend(repo_tags)
 
     print_header(
         'Running Quay Scale & Performance Tests',


### PR DESCRIPTION
### Description
Adds two new options `SKIP_PUSH` and `TAGS` to help with load testing of the registry proxy.

- `SKIP_PUSH` can be set to true when `TEST_PHASES=PUSH_PULL` to skip the first step of pushing tags to the registry.
- `TAGS` is a list of tags in a comma-separated string.

Example config:
```
- name: TEST_PHASES
  value: "PUSH_PULL"
- name: TAGS
  value: "registry.stage.redhat.io/ubi9/ubi,registry.stage.redhat.io/ubi9/podman" 
- name: SKIP_PUSH
  value: "true"
```
### Fixes
